### PR TITLE
feat: AA Deployment Paymaster

### DIFF
--- a/contracts/paymasters/AAFactoryPaymaster.sol
+++ b/contracts/paymasters/AAFactoryPaymaster.sol
@@ -50,10 +50,7 @@ contract AAFactoryPaymaster is IPaymaster {
         }
 
         if (address(uint160(_transaction.from)) != AccountFactory(AA_FACTORY).deployer()) {
-            (bytes32 salt, bytes memory initializer) = abi.decode(_transaction.data[4:], (bytes32, bytes));
-            if (keccak256(abi.encodePacked(address(uint160(_transaction.from)))) != salt) {
-                revert InvalidDeployer();
-            }
+            revert InvalidDeployer();
         }
 
         context = "";

--- a/contracts/paymasters/AAFactoryPaymaster.sol
+++ b/contracts/paymasters/AAFactoryPaymaster.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Transaction} from "@matterlabs/zksync-contracts/l2/system-contracts/libraries/TransactionHelper.sol";
+import {
+    IPaymaster,
+    ExecutionResult,
+    PAYMASTER_VALIDATION_SUCCESS_MAGIC
+} from "@matterlabs/zksync-contracts/l2/system-contracts/interfaces/IPaymaster.sol";
+import {AccountFactory} from "../AccountFactory.sol";
+
+import {BOOTLOADER_FORMAL_ADDRESS} from "@matterlabs/zksync-contracts/l2/system-contracts/Constants.sol";
+/**
+ * This Paymaster sponsors the gas for any user attempting to deploy an AGW account for themselves
+ * It also allows the canonical AGW deployer to sponsor deployments for users
+ */
+
+contract AAFactoryPaymaster is IPaymaster {
+    error OnlyDeployer();
+    error OnlyBootloader();
+    error MustCallAAFactory();
+    error MustCallCreateAccount();
+    error InvalidDeployer();
+    error WithdrawalFailed();
+    error BootloaderCallFailed();
+
+    address public immutable AA_FACTORY;
+    address private immutable _deployer;
+
+    constructor(address _aaFactory) {
+        AA_FACTORY = _aaFactory;
+        _deployer = msg.sender;
+    }
+
+    function validateAndPayForPaymasterTransaction(bytes32, bytes32, Transaction calldata _transaction)
+        external
+        payable
+        returns (bytes4 magic, bytes memory context)
+    {
+        if (msg.sender != BOOTLOADER_FORMAL_ADDRESS) {
+            revert OnlyBootloader();
+        }
+
+        if (address(uint160(_transaction.to)) != AA_FACTORY) {
+            revert MustCallAAFactory();
+        }
+
+        if (bytes4(_transaction.data[0:4]) != AccountFactory.deployAccount.selector) {
+            revert MustCallCreateAccount();
+        }
+
+        if (address(uint160(_transaction.from)) != AccountFactory(AA_FACTORY).deployer()) {
+            (bytes32 salt, bytes memory initializer) = abi.decode(_transaction.data[4:], (bytes32, bytes));
+            if (keccak256(abi.encodePacked(address(uint160(_transaction.from)))) != salt) {
+                revert InvalidDeployer();
+            }
+        }
+
+        context = "";
+        magic = PAYMASTER_VALIDATION_SUCCESS_MAGIC;
+
+        uint256 requiredETH = _transaction.gasLimit * _transaction.maxFeePerGas;
+
+        (bool success,) = BOOTLOADER_FORMAL_ADDRESS.call{value: requiredETH}("");
+        if (!success) {
+            revert BootloaderCallFailed();
+        }
+    }
+
+    function postTransaction(
+        bytes calldata _context,
+        Transaction calldata _transaction,
+        bytes32 _txHash,
+        bytes32 _suggestedSignedHash,
+        ExecutionResult _txResult,
+        uint256 _maxRefundedGas
+    ) external payable {}
+
+    function withdraw() external {
+        if (msg.sender != _deployer) {
+            revert OnlyDeployer();
+        }
+
+        (bool success,) = _deployer.call{value: address(this).balance}("");
+        revert WithdrawalFailed();
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
Creates an AA deployment paymaster that will only sponsor account creation for either
- The known AA deployer
- The account where the initial owner is the deployer

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on updating contract names and deploying logic related to AGW (Account Gateway) accounts. It introduces a new `AAFactoryPaymaster` contract for managing gas sponsorship for AGW account deployments.

### Detailed summary
- Replaced `ClaveImplementation` with `AGWAccount`.
- Replaced `ClaveRegistry` with `AGWRegistry`.
- Updated `ClaveProxy` to `AccountProxy`.
- Changed the salt generation method to use `keccak256`.
- Introduced `AAFactoryPaymaster` contract with validation and payment logic for AGW account deployments.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->