### PR TITLE
update error messaging

### DIFF
--- a/contracts/validators/SessionKeyValidator.sol
+++ b/contracts/validators/SessionKeyValidator.sol
@@ -46,7 +46,7 @@ contract SessionKeyValidator is IValidationHook, IModuleValidator, IModule {
     assembly {
       hookResult := tload(slot)
     }
-    require(hookResult == 1, "Can't call this function without calling validationHook");
+    require(hookResult == 1, "Session key validation failed. Please check session status and limits.");
     return true;
   }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the error message in the `SessionKeyValidator.sol` contract to provide clearer feedback when session key validation fails.

### Detailed summary
- Changed the error message in the `require` statement from `"Can't call this function without calling validationHook"` to `"Session key validation failed. Please check session status and limits."`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->