### PR TITLE
Fix/err

### DIFF
--- a/contracts/helpers/VerifierCaller.sol
+++ b/contracts/helpers/VerifierCaller.sol
@@ -38,7 +38,7 @@ abstract contract VerifierCaller {
             return returnValue == 1;
         }
 
-        // Otherwise return false for the unsucessful calls and invalid signatures
+        // Otherwise return false for the unsuccessful calls and invalid signatures
         return false;
     }
 }

--- a/contracts/paymasters/ERC20Paymaster.sol
+++ b/contracts/paymasters/ERC20Paymaster.sol
@@ -85,7 +85,7 @@ contract ERC20Paymaster is IPaymaster, PrimaryProdDataServiceConsumerBase, Ownab
         // By default we consider the transaction as accepted.
         magic = PAYMASTER_VALIDATION_SUCCESS_MAGIC;
 
-        // Revert if standart paymaster input is shorter than 4 bytes
+        // Revert if standard paymaster input is shorter than 4 bytes
         if (_transaction.paymasterInput.length < 4) revert Errors.SHORT_PAYMASTER_INPUT();
 
         // Check the paymaster input selector to detect flow


### PR DESCRIPTION
Fixed typos:  
- In `VerifierCaller.sol`, corrected `unsucessful` to `unsuccessful`.  
- In `ERC20Paymaster.sol`, corrected `standart` to `standard`.  


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos in comments within the Solidity contracts `VerifierCaller.sol` and `ERC20Paymaster.sol`.

### Detailed summary
- In `VerifierCaller.sol`, corrected "unsucessful" to "unsuccessful" in a comment.
- In `ERC20Paymaster.sol`, corrected "standart" to "standard" in a comment.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->