### PR TITLE
Fix spelling errors in AGWRegistry.sol, AccountFactory.sol, and hookmanager.test.ts

### DIFF
--- a/contracts/AGWRegistry.sol
+++ b/contracts/AGWRegistry.sol
@@ -27,7 +27,7 @@ contract AGWRegistry is Ownable2Step, IAGWRegistry {
     constructor(address _owner) Ownable(_owner) {}
 
     /**
-     * @notice Registers an account as a AGW account
+     * @notice Registers an account as an AGW account
      * @dev Can only be called by the factory or owner
      * @param account address - Address of the account to register
      */
@@ -55,7 +55,7 @@ contract AGWRegistry is Ownable2Step, IAGWRegistry {
     }
 
     /**
-     * @notice Unregisters an account as a AGW account
+     * @notice Unregisters an account as an AGW account
      * @dev Can only be called by the factory or owner
      * @param account address - Address of the account to unregister
      */

--- a/contracts/AccountFactory.sol
+++ b/contracts/AccountFactory.sol
@@ -167,7 +167,7 @@ contract AccountFactory is Ownable2Step {
     }
 
     /**
-     * @notice To emit an event when a AGW account is created but not yet deployed
+     * @notice To emit an event when an AGW account is created but not yet deployed
      * @dev This event is so that we can index accounts that are created but not yet deployed
      * @param accountAddress address - Address of the AGW account that was created
      */

--- a/test/accounts/managers/hookmanager.test.ts
+++ b/test/accounts/managers/hookmanager.test.ts
@@ -177,7 +177,7 @@ describe('AGW Contracts - Hook Manager tests', () => {
                 );
             });
 
-            it('should remove a execution hook', async () => {
+            it('should remove an execution hook', async () => {
                 expect(await account.isHook(await executionHook.getAddress()))
                     .to.be.true;
 

--- a/test/accounts/managers/hookmanager.test.ts
+++ b/test/accounts/managers/hookmanager.test.ts
@@ -155,7 +155,7 @@ describe('AGW Contracts - Hook Manager tests', () => {
                 );
             });
 
-            it('should add a execution hook', async () => {
+            it('should add an execution hook', async () => {
                 expect(await account.isHook(await executionHook.getAddress()))
                     .to.be.false;
 


### PR DESCRIPTION
- **AGWRegistry.sol**: Corrected "a AGW account" to "an AGW account" in multiple places.
- **AccountFactory.sol**: Corrected "a AGW account" to "an AGW account" in multiple places.
- **hookmanager.test.ts**: Fixed "a execution hook" to "an execution hook" in test descriptions.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the documentation and correcting minor wording issues in the comments of smart contracts and test files.

### Detailed summary
- Updated comment in `AccountFactory.sol` to correct "a AGW" to "an AGW".
- Updated test description in `hookmanager.test.ts` from "a execution hook" to "an execution hook" for consistency.
- Updated comment in `AGWRegistry.sol` to correct "a AGW" to "an AGW" in multiple places.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->