### PR TITLE
fix: Fix typo in VerifierCaller.sol

### DIFF
--- a/contracts/helpers/VerifierCaller.sol
+++ b/contracts/helpers/VerifierCaller.sol
@@ -38,7 +38,7 @@ abstract contract VerifierCaller {
             return returnValue == 1;
         }
 
-        // Otherwise return false for the unsucessful calls and invalid signatures
+        // Otherwise return false for the unsuccessful calls and invalid signatures
         return false;
     }
 }


### PR DESCRIPTION
A typo in `VerifierCaller.sol` where "unsucessful" was misspelled.
**This PR corrects it to "unsuccessful" for consistency and accuracy.** 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting a typo in the comment within the `VerifierCaller.sol` file. The change improves code clarity by fixing the misspelling of "unsuccessful".

### Detailed summary
- Corrected the comment from "unsucessful" to "unsuccessful" in `VerifierCaller.sol`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->