### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ PRIVATE_KEY=123cde574ccff....
 
 -   [Website](https://abs.xyz/)
 -   [GitHub](https://github.com/Abstract-Foundation)
--   [Twitter](https://twitter.com/AbstractChain)
+-   [Twitter](https://x.com/AbstractChain)


### PR DESCRIPTION
Updated the Twitter URL from https://twitter.com to https://x.com to reflect the platform's rebranding.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the link for the `Twitter` account in the `README.md` file from the old URL to the new one.

### Detailed summary
- Updated the `Twitter` link from `https://twitter.com/AbstractChain` to `https://x.com/AbstractChain`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->