### PR TITLE
feat: create session key policy registry

### DIFF
--- a/contracts/ERC1967Proxy.sol
+++ b/contracts/ERC1967Proxy.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v5.1.0) (proxy/ERC1967/ERC1967Proxy.sol)
+
+pragma solidity ^0.8.20;
+
+import {Proxy} from "@openzeppelin/contracts/proxy/Proxy.sol";
+import {ERC1967Utils} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Utils.sol";
+
+/**
+ * @dev This contract implements an upgradeable proxy. It is upgradeable because calls are delegated to an
+ * implementation address that can be changed. This address is stored in storage in the location specified by
+ * https://eips.ethereum.org/EIPS/eip-1967[ERC-1967], so that it doesn't conflict with the storage layout of the
+ * implementation behind the proxy.
+ */
+contract ERC1967Proxy is Proxy {
+    /**
+     * @dev Initializes the upgradeable proxy with an initial implementation specified by `implementation`.
+     *
+     * If `_data` is nonempty, it's used as data in a delegate call to `implementation`. This will typically be an
+     * encoded function call, and allows initializing the storage of the proxy like a Solidity constructor.
+     *
+     * Requirements:
+     *
+     * - If `data` is empty, `msg.value` must be zero.
+     */
+    constructor(address implementation, bytes memory _data) payable {
+        ERC1967Utils.upgradeToAndCall(implementation, _data);
+    }
+
+    /**
+     * @dev Returns the current implementation address.
+     *
+     * TIP: To get this value clients can read directly from the storage slot shown below (specified by ERC-1967) using
+     * the https://eth.wiki/json-rpc/API#eth_getstorageat[`eth_getStorageAt`] RPC call.
+     * `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc`
+     */
+    function _implementation() internal view virtual override returns (address) {
+        return ERC1967Utils.getImplementation();
+    }
+}

--- a/contracts/helpers/SessionKeyRegistry.sol
+++ b/contracts/helpers/SessionKeyRegistry.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 

--- a/contracts/helpers/SessionKeyRegistry.sol
+++ b/contracts/helpers/SessionKeyRegistry.sol
@@ -1,0 +1,60 @@
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {AccessControlUpgradeable} from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+
+enum PolicyType {
+    Call,
+    Transfer
+}
+
+enum Status {
+    Unset,
+    Allowed,
+    Blocked
+}
+
+contract SessionKeyPolicyRegistry is AccessControlUpgradeable, UUPSUpgradeable {
+    event PolicyStatusChanged(
+        PolicyType indexed policyType, address indexed target, bytes4 indexed selector, Status status
+    );
+
+    bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
+
+    mapping(bytes32 => Status) private _policyStatus;
+
+    constructor() {
+        _disableInitializers();
+    }
+
+    function initialize(address owner) public initializer {
+        _grantRole(DEFAULT_ADMIN_ROLE, owner);
+        _grantRole(MANAGER_ROLE, owner);
+    }
+
+    function setCallPolicyStatus(address target, bytes4 selector, Status status) public onlyRole(MANAGER_ROLE) {
+        _setPolicyStatus(PolicyType.Call, target, selector, status);
+    }
+
+    function setTransferPolicyStatus(address target, Status status) public onlyRole(MANAGER_ROLE) {
+        _setPolicyStatus(PolicyType.Transfer, target, bytes4(0), status);
+    }
+
+    function getCallPolicyStatus(address target, bytes4 selector) public view returns (Status) {
+        return _getPolicyStatus(PolicyType.Call, target, selector);
+    }
+
+    function getTransferPolicyStatus(address target) public view returns (Status) {
+        return _getPolicyStatus(PolicyType.Transfer, target, bytes4(0));
+    }
+
+    function _setPolicyStatus(PolicyType policyType, address target, bytes4 selector, Status status) internal {
+        _policyStatus[keccak256(abi.encodePacked(policyType, target, selector))] = status;
+
+        emit PolicyStatusChanged(policyType, target, selector, status);
+    }
+
+    function _getPolicyStatus(PolicyType policyType, address target, bytes4 selector) internal view returns (Status) {
+        return _policyStatus[keccak256(abi.encodePacked(policyType, target, selector))];
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyRole(DEFAULT_ADMIN_ROLE) {}
+}

--- a/deploy/deploy-session-key-registry.ts
+++ b/deploy/deploy-session-key-registry.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright Clave - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+import {
+    AbiCoder,
+    ZeroHash,
+} from 'ethers';
+import * as hre from 'hardhat';
+import { Contract, Wallet, utils } from 'zksync-ethers';
+import { deployContract, getProvider, getWallet } from '../deploy/utils';
+let fundingWallet: Wallet;
+
+// An example of a basic deploy script
+// Do not push modifications to this file
+// Just modify, interact then revert changes
+export default async function (): Promise<void> {
+    fundingWallet = getWallet(hre);
+
+    const initialOwner = fundingWallet.address;
+
+    const implementation = await create2IfNotExists("SessionKeyPolicyRegistry", []);
+
+    await create2IfNotExists("ERC1967Proxy", [
+        await implementation.getAddress(), 
+        implementation.interface.encodeFunctionData("initialize", [initialOwner])
+    ]);
+}
+
+async function create2IfNotExists(contractName: string, constructorArguments: any[]): Promise<Contract> {
+
+    const artifact = await hre.zksyncEthers.loadArtifact(contractName);
+    const bytecodeHash = utils.hashBytecode(artifact.bytecode);
+
+    const constructor = artifact.abi.find(abi => abi.type === "constructor");
+
+    let encodedConstructorArguments = "0x";
+    if (constructor) {
+        encodedConstructorArguments = AbiCoder.defaultAbiCoder().encode(constructor.inputs, constructorArguments);
+    }
+
+    const address = utils.create2Address("0x0000000000000000000000000000000000010000", bytecodeHash, ZeroHash, encodedConstructorArguments);
+    
+    const provider = getProvider(hre);
+    const code = await provider.getCode(address);
+    if (code !== "0x") {
+        console.log(`Contract ${contractName} already deployed at ${address}`);
+
+        // enable this to verify the contracts on a subsequent run
+        // await verifyContract(hre, {
+        //     address,
+        //     contract: artifact.sourceName,
+        //     constructorArguments: encodedConstructorArguments,
+        //     bytecode: artifact.bytecode
+        // })
+
+        return new Contract(address, artifact.abi, getWallet(hre));
+    }
+
+    return deployContract(hre, contractName, constructorArguments, {
+        wallet: getWallet(hre),
+        silent: false,
+    }, 'create2');
+
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lint": "npx prettier --write --plugin=prettier-plugin-solidity 'contracts/**/*.sol'",
     "lint-check": "npx prettier --list-different --plugin=prettier-plugin-solidity 'contracts/**/*.sol'",
     "test": "TEST=true npx hardhat test --network hardhat",
-    "deploy-factory": "hardhat deploy-zksync --script deploy.ts --network abstractTestnet"
+    "deploy-factory": "hardhat deploy-zksync --script deploy.ts --network abstractTestnet",
+    "deploy-session-key-registry": "hardhat deploy-zksync --script deploy-session-key-registry.ts --network abstractTestnet"
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new `SessionKeyPolicyRegistry` contract and an upgradeable `ERC1967Proxy`, enhancing contract management and deployment capabilities. It also updates the `package.json` to include a new deployment script.

### Detailed summary
- Added `ERC1967Proxy` contract for upgradeable proxy functionality.
- Introduced `SessionKeyPolicyRegistry` contract for managing policy statuses.
- Updated `package.json` with a new script `deploy-session-key-registry` for deployment.
- Adjusted existing `deploy-factory` script format.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->