### PR TITLE
feat: add approved session keys to registry script

### DIFF
--- a/deploy/add-approved-session-keys-to-registry.ts
+++ b/deploy/add-approved-session-keys-to-registry.ts
@@ -19,7 +19,9 @@ export default async function (): Promise<void> {
       ? process.argv[process.argv.slice(2).indexOf("--registry-address") + 3]
       : DEFAULT_REGISTRY_ADDRESS;
 
-  console.log(`Using SessionKeyPolicyRegistry at address: ${registryAddress}`);
+  console.log(
+    `Using SessionKeyPolicyRegistry at address: ${registryAddress}\n`
+  );
 
   // Connect to the registry contract
   const artifact = await hre.zksyncEthers.loadArtifact(
@@ -52,13 +54,12 @@ export default async function (): Promise<void> {
         );
 
         if (currentStatus === config.status) {
-          console.log(
+          console.warn(
             `${description} already set to ${Status[config.status]}. Skipping.`
           );
           return;
         }
 
-        console.log(`Adding ${description}`);
         tx = await registry.setCallPolicyStatus(
           config.target,
           config.selector,
@@ -71,13 +72,12 @@ export default async function (): Promise<void> {
         currentStatus = await registry.getTransferPolicyStatus(config.target);
 
         if (currentStatus === config.status) {
-          console.log(
+          console.warn(
             `${description} already set to ${Status[config.status]}. Skipping.`
           );
           return;
         }
 
-        console.log(`Adding ${description}`);
         tx = await registry.setTransferPolicyStatus(
           config.target,
           config.status
@@ -92,13 +92,12 @@ export default async function (): Promise<void> {
         );
 
         if (currentStatus === config.status) {
-          console.log(
+          console.warn(
             `${description} already set to ${Status[config.status]}. Skipping.`
           );
           return;
         }
 
-        console.log(`Adding ${description}`);
         tx = await registry.setApprovalTargetStatus(
           config.token,
           config.target,
@@ -107,22 +106,21 @@ export default async function (): Promise<void> {
         break;
 
       default:
-        console.warn(`Unknown policy type: ${(config as any).type}. Skipping.`);
+        console.error(
+          `Unknown policy type: ${(config as any).type}. Skipping.`
+        );
         return;
     }
 
     await tx.wait();
-    console.log(`Transaction successful: ${tx.hash}`);
+    console.log(
+      `Added ${description}` + `\n` + `Transaction hash: ${tx.hash}` + `\n`
+    );
   }
 
   // Process each session key configuration
   for (const config of sessionKeysToApprove) {
-    try {
-      // Type assertion needed because sessionKeysToApprove may not fully match our PolicyConfig type
-      await processPolicyConfig(config);
-    } catch (error) {
-      console.error(`Error adding session key configuration:`, error);
-    }
+    await processPolicyConfig(config);
   }
 
   console.log(

--- a/deploy/add-approved-session-keys-to-registry.ts
+++ b/deploy/add-approved-session-keys-to-registry.ts
@@ -1,0 +1,277 @@
+/**
+ * Copyright Clave - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ */
+import * as hre from "hardhat";
+import { Contract, utils } from "zksync-ethers";
+import { ZeroHash } from "ethers";
+import { getWallet } from "../deploy/utils";
+
+enum PolicyType {
+  Call = 0,
+  Transfer = 1,
+  ApprovalTarget = 2,
+}
+
+enum Status {
+  Unset = 0,
+  Allowed = 1,
+  Blocked = 2,
+}
+
+const sessionKeysToApprove: any[] = [
+  // Call policies for various contracts
+  // From the first sample config
+  {
+    type: PolicyType.Call,
+    target: "0xF99E6e273a90Fac72F3692B033A46e8b602DC44e",
+    selector: "0x42966c68", // burnAndMint selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x57E12aBdF617FcD0D2ab6984C289075aA90CAc8C",
+    selector: "0xa22cb465", // setApprovalForAll selector
+    status: Status.Allowed,
+  },
+  // From the second sample config
+  {
+    type: PolicyType.Call,
+    target: "0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d",
+    selector: "0x3beba5c7",
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d",
+    selector: "0x00f041ef",
+    status: Status.Allowed,
+  },
+  // From the third sample config
+  {
+    type: PolicyType.Call,
+    target: "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+    selector: "0x095ea7b3", // approve selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0xb1a1a882", // depositETH selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0x47e7ef24", // deposit selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0x4782f779", // withdrawETH selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0x69328dec", // withdraw selector
+    status: Status.Allowed,
+  },
+  // From the fourth sample config
+  {
+    type: PolicyType.Call,
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    selector: "0xe4849b32", // sell selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    selector: "0xd6bbd32d", // buy selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    selector: "0x4f1ddc4f", // claimWinnings selector
+    status: Status.Allowed,
+  },
+  // Approval targets from the fourth sample config
+  {
+    type: PolicyType.ApprovalTarget,
+    token: "0xf19609e96187cdaa34cffb96473fac567e547302", // PTS
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.ApprovalTarget,
+    token: "0x9ebe3a824ca958e4b3da772d2065518f009cba62", // PENGU
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.ApprovalTarget,
+    token: "0x84a71ccd554cc1b02749b35d22f684cc8ec987e1", // USDC
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    status: Status.Allowed,
+  },
+  // From the fifth sample config
+  {
+    type: PolicyType.Call,
+    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
+    selector: "0xf088d547", // buy selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
+    selector: "0xe65e7daf", // sell selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
+    selector: "0x2a1b1f7f", // deployToken selector
+    status: Status.Allowed,
+  },
+  // From the sixth sample config
+  {
+    type: PolicyType.Call,
+    target: "0x3439153EB7AF838Ad19d56E1571FBD09333C2809",
+    selector: "0x2e1a7d4d", // withdraw selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
+    selector: "0x8f5d96d0", // purchaseETH selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
+    selector: "0x4e71d92d", // claim selector
+    status: Status.Allowed,
+  },
+  // From the seventh sample config
+  {
+    type: PolicyType.Call,
+    target: "0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9",
+    selector: "0x9b2c0a37", // requestTokenSpin selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.ApprovalTarget,
+    token: "0x9ebe3a824ca958e4b3da772d2065518f009cba62", // PENGU
+    target: "0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9",
+    status: Status.Allowed,
+  },
+];
+
+export default async function (): Promise<void> {
+  // Get the wallet for signing transactions
+  const wallet = getWallet(hre);
+
+  // Get the registry contract address
+  // This assumes the registry was deployed using create2 with the same parameters as in deploy-session-key-registry.ts
+  const artifact = await hre.zksyncEthers.loadArtifact(
+    "SessionKeyPolicyRegistry"
+  );
+  const bytecodeHash = utils.hashBytecode(artifact.bytecode);
+  const implementationAddress = utils.create2Address(
+    "0x0000000000000000000000000000000000010000",
+    bytecodeHash,
+    ZeroHash,
+    "0x"
+  );
+
+  // Get the proxy artifact
+  const proxyArtifact = await hre.zksyncEthers.loadArtifact("ERC1967Proxy");
+  const proxyBytecodeHash = utils.hashBytecode(proxyArtifact.bytecode);
+
+  // Calculate the proxy address
+  const initialOwner = wallet.address;
+  const contract = new Contract(implementationAddress, artifact.abi);
+  const initData = contract.interface.encodeFunctionData("initialize", [
+    initialOwner,
+  ]);
+
+  const constructorArgs = [implementationAddress, initData];
+
+  const encodedConstructorArguments =
+    hre.ethers.AbiCoder.defaultAbiCoder().encode(
+      ["address", "bytes"],
+      constructorArgs
+    );
+
+  const proxyAddress = utils.create2Address(
+    "0x0000000000000000000000000000000000010000",
+    proxyBytecodeHash,
+    ZeroHash,
+    encodedConstructorArguments
+  );
+
+  console.log(`SessionKeyPolicyRegistry proxy address: ${proxyAddress}`);
+
+  // Connect to the registry contract
+  const registry = new Contract(proxyAddress, artifact.abi, wallet);
+
+  // Check if the wallet has the MANAGER_ROLE
+  const MANAGER_ROLE = await registry.MANAGER_ROLE();
+  const hasRole = await registry.hasRole(MANAGER_ROLE, wallet.address);
+
+  if (!hasRole) {
+    console.error(
+      `Wallet ${wallet.address} does not have the MANAGER_ROLE. Cannot add session keys.`
+    );
+    return;
+  }
+
+  // Add each session key configuration to the registry
+  for (const config of sessionKeysToApprove) {
+    try {
+      let tx;
+
+      if (config.type === PolicyType.Call) {
+        console.log(
+          `Adding Call policy for target: ${config.target}, selector: ${config.selector}`
+        );
+        tx = await registry.setCallPolicyStatus(
+          config.target,
+          config.selector,
+          config.status
+        );
+      } else if (config.type === PolicyType.Transfer) {
+        console.log(`Adding Transfer policy for target: ${config.target}`);
+        tx = await registry.setTransferPolicyStatus(
+          config.target,
+          config.status
+        );
+      } else if (config.type === PolicyType.ApprovalTarget) {
+        console.log(
+          `Adding Approval Target policy for token: ${config.token}, target: ${config.target}`
+        );
+        tx = await registry.setApprovalTargetStatus(
+          config.token,
+          config.target,
+          config.status
+        );
+      } else {
+        console.warn(`Unknown policy type: ${config.type}. Skipping.`);
+        continue;
+      }
+
+      // Wait for the transaction to be mined
+      await tx.wait();
+      console.log(`Transaction successful: ${tx.hash}`);
+    } catch (error) {
+      console.error(`Error adding session key configuration:`, error);
+    }
+  }
+
+  console.log(
+    `Successfully added ${sessionKeysToApprove.length} session key configurations to the registry.`
+  );
+}

--- a/deploy/add-approved-session-keys-to-registry.ts
+++ b/deploy/add-approved-session-keys-to-registry.ts
@@ -1,227 +1,35 @@
-/**
- * Copyright Clave - All Rights Reserved
- * Unauthorized copying of this file, via any medium is strictly prohibited
- * Proprietary and confidential
- */
 import * as hre from "hardhat";
-import { Contract, utils } from "zksync-ethers";
-import { ZeroHash } from "ethers";
+import { Contract } from "zksync-ethers";
 import { getWallet } from "../deploy/utils";
-
-enum PolicyType {
-  Call = 0,
-  Transfer = 1,
-  ApprovalTarget = 2,
-}
-
-enum Status {
-  Unset = 0,
-  Allowed = 1,
-  Blocked = 2,
-}
-
-const sessionKeysToApprove: any[] = [
-  // Call policies for various contracts
-  // From the first sample config
-  {
-    type: PolicyType.Call,
-    target: "0xF99E6e273a90Fac72F3692B033A46e8b602DC44e",
-    selector: "0x42966c68", // burnAndMint selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x57E12aBdF617FcD0D2ab6984C289075aA90CAc8C",
-    selector: "0xa22cb465", // setApprovalForAll selector
-    status: Status.Allowed,
-  },
-  // From the second sample config
-  {
-    type: PolicyType.Call,
-    target: "0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d",
-    selector: "0x3beba5c7",
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d",
-    selector: "0x00f041ef",
-    status: Status.Allowed,
-  },
-  // From the third sample config
-  {
-    type: PolicyType.Call,
-    target: "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-    selector: "0x095ea7b3", // approve selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0xb1a1a882", // depositETH selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0x47e7ef24", // deposit selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0x4782f779", // withdrawETH selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0x69328dec", // withdraw selector
-    status: Status.Allowed,
-  },
-  // From the fourth sample config
-  {
-    type: PolicyType.Call,
-    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    selector: "0xe4849b32", // sell selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    selector: "0xd6bbd32d", // buy selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    selector: "0x4f1ddc4f", // claimWinnings selector
-    status: Status.Allowed,
-  },
-  // Approval targets from the fourth sample config
-  {
-    type: PolicyType.ApprovalTarget,
-    token: "0xf19609e96187cdaa34cffb96473fac567e547302", // PTS
-    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.ApprovalTarget,
-    token: "0x9ebe3a824ca958e4b3da772d2065518f009cba62", // PENGU
-    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.ApprovalTarget,
-    token: "0x84a71ccd554cc1b02749b35d22f684cc8ec987e1", // USDC
-    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    status: Status.Allowed,
-  },
-  // From the fifth sample config
-  {
-    type: PolicyType.Call,
-    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
-    selector: "0xf088d547", // buy selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
-    selector: "0xe65e7daf", // sell selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
-    selector: "0x2a1b1f7f", // deployToken selector
-    status: Status.Allowed,
-  },
-  // From the sixth sample config
-  {
-    type: PolicyType.Call,
-    target: "0x3439153EB7AF838Ad19d56E1571FBD09333C2809",
-    selector: "0x2e1a7d4d", // withdraw selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
-    selector: "0x8f5d96d0", // purchaseETH selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.Call,
-    target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
-    selector: "0x4e71d92d", // claim selector
-    status: Status.Allowed,
-  },
-  // From the seventh sample config
-  {
-    type: PolicyType.Call,
-    target: "0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9",
-    selector: "0x9b2c0a37", // requestTokenSpin selector
-    status: Status.Allowed,
-  },
-  {
-    type: PolicyType.ApprovalTarget,
-    token: "0x9ebe3a824ca958e4b3da772d2065518f009cba62", // PENGU
-    target: "0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9",
-    status: Status.Allowed,
-  },
-];
+import {
+  PolicyConfig,
+  PolicyType,
+  sessionKeysToApprove,
+  Status,
+} from "./const/session-key-configs";
 
 export default async function (): Promise<void> {
   // Get the wallet for signing transactions
   const wallet = getWallet(hre);
 
-  // Get the registry contract address
-  // This assumes the registry was deployed using create2 with the same parameters as in deploy-session-key-registry.ts
+  // Use the default registry contract address from create2 or override if one is provided via CLI args
+  const DEFAULT_REGISTRY_ADDRESS = "0x7dA0211D162a26839Bbb8232Da13fbE068440d95";
+  const registryAddress =
+    process.argv.slice(2).indexOf("--registry-address") >= 0
+      ? process.argv[process.argv.slice(2).indexOf("--registry-address") + 3]
+      : DEFAULT_REGISTRY_ADDRESS;
+
+  console.log(`Using SessionKeyPolicyRegistry at address: ${registryAddress}`);
+
+  // Connect to the registry contract
   const artifact = await hre.zksyncEthers.loadArtifact(
     "SessionKeyPolicyRegistry"
   );
-  const bytecodeHash = utils.hashBytecode(artifact.bytecode);
-  const implementationAddress = utils.create2Address(
-    "0x0000000000000000000000000000000000010000",
-    bytecodeHash,
-    ZeroHash,
-    "0x"
-  );
+  const registry = new Contract(registryAddress, artifact.abi, wallet);
 
-  // Get the proxy artifact
-  const proxyArtifact = await hre.zksyncEthers.loadArtifact("ERC1967Proxy");
-  const proxyBytecodeHash = utils.hashBytecode(proxyArtifact.bytecode);
-
-  // Calculate the proxy address
-  const initialOwner = wallet.address;
-  const contract = new Contract(implementationAddress, artifact.abi);
-  const initData = contract.interface.encodeFunctionData("initialize", [
-    initialOwner,
-  ]);
-
-  const constructorArgs = [implementationAddress, initData];
-
-  const encodedConstructorArguments =
-    hre.ethers.AbiCoder.defaultAbiCoder().encode(
-      ["address", "bytes"],
-      constructorArgs
-    );
-
-  const proxyAddress = utils.create2Address(
-    "0x0000000000000000000000000000000000010000",
-    proxyBytecodeHash,
-    ZeroHash,
-    encodedConstructorArguments
-  );
-
-  console.log(`SessionKeyPolicyRegistry proxy address: ${proxyAddress}`);
-
-  // Connect to the registry contract
-  const registry = new Contract(proxyAddress, artifact.abi, wallet);
-
-  // Check if the wallet has the MANAGER_ROLE
+  // Check if the wallet has the MANAGER_ROLE to add policies to the registry
   const MANAGER_ROLE = await registry.MANAGER_ROLE();
   const hasRole = await registry.hasRole(MANAGER_ROLE, wallet.address);
-
   if (!hasRole) {
     console.error(
       `Wallet ${wallet.address} does not have the MANAGER_ROLE. Cannot add session keys.`
@@ -229,43 +37,89 @@ export default async function (): Promise<void> {
     return;
   }
 
-  // Add each session key configuration to the registry
-  for (const config of sessionKeysToApprove) {
-    try {
-      let tx;
+  // Helper function to process a policy configuration
+  async function processPolicyConfig(config: PolicyConfig): Promise<void> {
+    let currentStatus;
+    let tx;
+    let description = "";
 
-      if (config.type === PolicyType.Call) {
-        console.log(
-          `Adding Call policy for target: ${config.target}, selector: ${config.selector}`
+    switch (config.type) {
+      case PolicyType.Call:
+        description = `Call policy for target: ${config.target}, selector: ${config.selector}`;
+        currentStatus = await registry.getCallPolicyStatus(
+          config.target,
+          config.selector
         );
+
+        if (currentStatus === config.status) {
+          console.log(
+            `${description} already set to ${Status[config.status]}. Skipping.`
+          );
+          return;
+        }
+
+        console.log(`Adding ${description}`);
         tx = await registry.setCallPolicyStatus(
           config.target,
           config.selector,
           config.status
         );
-      } else if (config.type === PolicyType.Transfer) {
-        console.log(`Adding Transfer policy for target: ${config.target}`);
+        break;
+
+      case PolicyType.Transfer:
+        description = `Transfer policy for target: ${config.target}`;
+        currentStatus = await registry.getTransferPolicyStatus(config.target);
+
+        if (currentStatus === config.status) {
+          console.log(
+            `${description} already set to ${Status[config.status]}. Skipping.`
+          );
+          return;
+        }
+
+        console.log(`Adding ${description}`);
         tx = await registry.setTransferPolicyStatus(
           config.target,
           config.status
         );
-      } else if (config.type === PolicyType.ApprovalTarget) {
-        console.log(
-          `Adding Approval Target policy for token: ${config.token}, target: ${config.target}`
+        break;
+
+      case PolicyType.ApprovalTarget:
+        description = `Approval Target policy for token: ${config.token}, target: ${config.target}`;
+        currentStatus = await registry.getApprovalTargetStatus(
+          config.token,
+          config.target
         );
+
+        if (currentStatus === config.status) {
+          console.log(
+            `${description} already set to ${Status[config.status]}. Skipping.`
+          );
+          return;
+        }
+
+        console.log(`Adding ${description}`);
         tx = await registry.setApprovalTargetStatus(
           config.token,
           config.target,
           config.status
         );
-      } else {
-        console.warn(`Unknown policy type: ${config.type}. Skipping.`);
-        continue;
-      }
+        break;
 
-      // Wait for the transaction to be mined
-      await tx.wait();
-      console.log(`Transaction successful: ${tx.hash}`);
+      default:
+        console.warn(`Unknown policy type: ${(config as any).type}. Skipping.`);
+        return;
+    }
+
+    await tx.wait();
+    console.log(`Transaction successful: ${tx.hash}`);
+  }
+
+  // Process each session key configuration
+  for (const config of sessionKeysToApprove) {
+    try {
+      // Type assertion needed because sessionKeysToApprove may not fully match our PolicyConfig type
+      await processPolicyConfig(config);
     } catch (error) {
       console.error(`Error adding session key configuration:`, error);
     }

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -69,9 +69,9 @@ const sampleConfig1: PolicyConfig[] = [
 
 const sampleConfig2: PolicyConfig[] = [
   {
-    type: PolicyType.Call,
-    target: "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
-    selector: "0x095ea7b3", // approve selector
+    type: PolicyType.ApprovalTarget,
+    token: "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1", // USDC
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
     status: Status.Allowed,
   },
   {

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -214,6 +214,93 @@ const sampleConfig6: PolicyConfig[] = [
   },
 ];
 
+const sampleConfig7: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x03c9FEC896BC1a69EDAafaC47B6A1D473b864078",
+    selector: "0x073f5da3", // joinTournament selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0C1Fb514EEe951F43d549666Bec113D9ADcFBf98",
+    selector: "0xda568094", // claimPrize selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0C1Fb514EEe951F43d549666Bec113D9ADcFBf98",
+    selector: "0xdaa462ae", // claimMultiplePrizes selector
+    status: Status.Allowed,
+  },
+
+  // TODO: Add claimReferral
+  // TODO: Add claimMultipleReferrals
+];
+
+const sampleConfig8: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0xdef25acb", // createDrop selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0x7f58b4bf", // mintToken selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0xeefdc1df", // mintTokenByCreator
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0x42d96dd7", // refundToken selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0x91eb290e", // batchRedeem selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0x96949420", // joinQueue selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0xae796ab3", // leaveQueue selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0x0dce83c7", // commitQueue selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0xd8d07eda", // revealQueue selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0x5beaa049", // claimFromQueue selector
+    status: Status.Allowed,
+  },
+];
+
 // Session key configurations to approve from the sample configurations
 export const sessionKeysToApprove: PolicyConfig[] = [
   ...sampleConfig0,
@@ -223,4 +310,6 @@ export const sessionKeysToApprove: PolicyConfig[] = [
   ...sampleConfig4,
   ...sampleConfig5,
   ...sampleConfig6,
+  ...sampleConfig7,
+  ...sampleConfig8,
 ];

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -1,0 +1,226 @@
+export enum PolicyType {
+  Call = 0,
+  Transfer = 1,
+  ApprovalTarget = 2,
+}
+
+export enum Status {
+  Unset = 0,
+  Allowed = 1,
+  Blocked = 2,
+}
+
+interface BaseConfig {
+  type: PolicyType;
+  status: Status;
+}
+
+interface CallPolicyConfig extends BaseConfig {
+  type: PolicyType.Call;
+  target: string;
+  selector: string;
+}
+
+interface TransferPolicyConfig extends BaseConfig {
+  type: PolicyType.Transfer;
+  target: string;
+}
+
+interface ApprovalTargetPolicyConfig extends BaseConfig {
+  type: PolicyType.ApprovalTarget;
+  token: string;
+  target: string;
+}
+
+export type PolicyConfig =
+  | CallPolicyConfig
+  | TransferPolicyConfig
+  | ApprovalTargetPolicyConfig;
+
+const sampleConfig0: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x57E12aBdF617FcD0D2ab6984C289075aA90CAc8C",
+    selector: "0xa22cb465", // setApprovalForAll selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0xF99E6e273a90Fac72F3692B033A46e8b602DC44e",
+    selector: "0x42966c68", // burnAndMint selector
+    status: Status.Allowed,
+  },
+];
+
+const sampleConfig1: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d",
+    selector: "0x3beba5c7",
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d",
+    selector: "0x00f041ef",
+    status: Status.Allowed,
+  },
+];
+
+const sampleConfig2: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x84A71ccD554Cc1b02749b35d22F684CC8ec987e1",
+    selector: "0x095ea7b3", // approve selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0xb1a1a882", // depositETH selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0x47e7ef24", // deposit selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0x4782f779", // withdrawETH selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0x69328dec", // withdraw selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0xc2708f09", // expire selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0xbc011e72", // solve selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
+    selector: "0x19b410fe", // coin selector
+    status: Status.Allowed,
+  },
+];
+
+const sampleConfig3: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    selector: "0xe4849b32", // sell selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    selector: "0xd6bbd32d", // buy selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    selector: "0x4f1ddc4f", // claimWinnings selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.ApprovalTarget,
+    token: "0xf19609e96187cdaa34cffb96473fac567e547302", // PTS
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.ApprovalTarget,
+    token: "0x9ebe3a824ca958e4b3da772d2065518f009cba62", // PENGU
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.ApprovalTarget,
+    token: "0x84a71ccd554cc1b02749b35d22f684cc8ec987e1", // USDC
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    status: Status.Allowed,
+  },
+];
+
+const sampleConfig4: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
+    selector: "0xf088d547", // buy selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
+    selector: "0xe65e7daf", // sell selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
+    selector: "0x2a1b1f7f", // deployToken selector
+    status: Status.Allowed,
+  },
+];
+
+const sampleConfig5: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x3439153EB7AF838Ad19d56E1571FBD09333C2809",
+    selector: "0x2e1a7d4d", // withdraw selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
+    selector: "0x8f5d96d0", // purchaseETH selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
+    selector: "0x4e71d92d", // claim selector
+    status: Status.Allowed,
+  },
+];
+
+const sampleConfig6: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9",
+    selector: "0x9b2c0a37", // requestTokenSpin selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.ApprovalTarget,
+    token: "0x9ebe3a824ca958e4b3da772d2065518f009cba62", // PENGU
+    target: "0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9",
+    status: Status.Allowed,
+  },
+];
+
+// Session key configurations to approve from the sample configurations
+export const sessionKeysToApprove: PolicyConfig[] = [
+  ...sampleConfig0,
+  ...sampleConfig1,
+  ...sampleConfig2,
+  ...sampleConfig3,
+  ...sampleConfig4,
+  ...sampleConfig5,
+  ...sampleConfig6,
+];

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -202,14 +202,14 @@ const sampleConfig5: PolicyConfig[] = [
 const sampleConfig6: PolicyConfig[] = [
   {
     type: PolicyType.Call,
-    target: "0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9",
+    target: "0xB4b55C656c6b89f020a6E1044B66D227B638C474",
     selector: "0x9b2c0a37", // requestTokenSpin selector
     status: Status.Allowed,
   },
   {
     type: PolicyType.ApprovalTarget,
     token: "0x9ebe3a824ca958e4b3da772d2065518f009cba62", // PENGU
-    target: "0xA27f718c7fB6e5f1eaEb894597143B6b880a3ae9",
+    target: "0xB4b55C656c6b89f020a6E1044B66D227B638C474",
     status: Status.Allowed,
   },
 ];

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -233,9 +233,18 @@ const sampleConfig7: PolicyConfig[] = [
     selector: "0xdaa462ae", // claimMultiplePrizes selector
     status: Status.Allowed,
   },
-
-  // TODO: Add claimReferral
-  // TODO: Add claimMultipleReferrals
+  {
+    type: PolicyType.Call,
+    target: "0x1FD611a870c44f8EFa82CF62B67499D141abD7E9",
+    selector: "0x8589ee97", // claimReferral selector
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x1FD611a870c44f8EFa82CF62B67499D141abD7E9",
+    selector: "0xda4053ac", // claimMultipleReferrals selector
+    status: Status.Allowed,
+  },
 ];
 
 const sampleConfig8: PolicyConfig[] = [

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -55,13 +55,13 @@ const sampleConfig0: PolicyConfig[] = [
 const sampleConfig1: PolicyConfig[] = [
   {
     type: PolicyType.Call,
-    target: "0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d",
+    target: "0x11614eE1eF07dEe4AC28893a00F6F63B13223906",
     selector: "0x3beba5c7",
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
-    target: "0xe88ba37DE1F9d88989ae079AB6876F917EF64f3d",
+    target: "0x11614eE1eF07dEe4AC28893a00F6F63B13223906",
     selector: "0x00f041ef",
     status: Status.Allowed,
   },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lint-check": "npx prettier --list-different --plugin=prettier-plugin-solidity 'contracts/**/*.sol'",
     "test": "TEST=true npx hardhat test --network hardhat",
     "deploy-factory": "hardhat deploy-zksync --script deploy.ts --network abstractTestnet",
-    "deploy-session-key-registry": "hardhat deploy-zksync --script deploy-session-key-registry.ts --network abstractTestnet"
+    "deploy-session-key-registry": "hardhat deploy-zksync --script deploy-session-key-registry.ts --network abstractTestnet",
+    "add-approved-session-keys-to-registry": "hardhat deploy-zksync --script add-approved-session-keys-to-registry.ts --network abstractTestnet"
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new script to add approved session keys to a registry, enhancing the management of session key policies. It also updates the `package.json` and defines new policy configurations.

### Detailed summary
- Added `add-approved-session-keys-to-registry` script in `package.json`.
- Created `deploy/add-approved-session-keys-to-registry.ts` to handle session key approvals.
- Defined new enums and interfaces in `deploy/const/session-key-configs.ts` for policy types and configurations.
- Implemented logic to check roles and process various policy configurations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->