### PR TITLE
feat: onchain feature flag registry

### DIFF
--- a/contracts/helpers/FeatureFlagRegistry.sol
+++ b/contracts/helpers/FeatureFlagRegistry.sol
@@ -3,6 +3,10 @@ pragma solidity 0.8.26;
 
 import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 
+/**
+ * @title FeatureFlagRegistry
+ * @notice A contract for managing feature flags onchain
+ */
 contract FeatureFlagRegistry is AccessControl {
     error Immutable();
 
@@ -11,26 +15,41 @@ contract FeatureFlagRegistry is AccessControl {
 
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
 
-    mapping(bytes32 => mapping(address => bool)) public featureFlagStatus;
+    mapping(bytes32 => mapping(address => bool)) private _featureFlagStatus;
     mapping(bytes32 => bool) public featureFlagImmutable;
 
+    /**
+     * @notice Initializes the contract with an owner who receives the DEFAULT_ADMIN_ROLE
+     * @param owner Address that will be granted the admin role
+     */
     constructor(address owner) {
         _grantRole(DEFAULT_ADMIN_ROLE, owner);
     }
 
-    function setFeatureFlagStatus(string memory featureFlag, address user, bool status)
-        public
-        onlyRole(MANAGER_ROLE)
-    {
+    /**
+     * @notice Sets the status of a feature flag for a specific user; specify zero address to set the global status
+     * @dev Only callable by accounts with MANAGER_ROLE
+     * @param featureFlag String identifier of the feature flag
+     * @param user Address of the user to set the status for
+     * @param status Boolean indicating if the feature should be enabled
+     * @custom:throws Immutable if the feature flag has been made immutable
+     */
+    function setFeatureFlagStatus(string memory featureFlag, address user, bool status) public onlyRole(MANAGER_ROLE) {
         bytes32 featureFlagHash = _hashFeatureFlag(featureFlag);
         if (featureFlagImmutable[featureFlagHash]) {
             revert Immutable();
         }
-        featureFlagStatus[featureFlagHash][user] = status;
+        _featureFlagStatus[featureFlagHash][user] = status;
 
         emit FeatureFlagEnabled(featureFlagHash, user, status);
     }
 
+    /**
+     * @notice Makes a feature flag immutable, preventing future status changes
+     * @dev Only callable by accounts with MANAGER_ROLE
+     * @param featureFlag String identifier of the feature flag
+     * @custom:throws Immutable if the feature flag is already immutable
+     */
     function setFeatureFlagImmutable(string memory featureFlag) public onlyRole(MANAGER_ROLE) {
         bytes32 featureFlagHash = _hashFeatureFlag(featureFlag);
         if (featureFlagImmutable[featureFlagHash]) {
@@ -39,23 +58,42 @@ contract FeatureFlagRegistry is AccessControl {
         featureFlagImmutable[featureFlagHash] = true;
     }
 
+    /**
+     * @notice Checks if a feature flag is enabled for a specific user
+     * @param featureFlag String identifier of the feature flag
+     * @param user Address of the user to check
+     * @return bool True if the feature is enabled for the user
+     */
     function isFeatureFlagEnabled(string memory featureFlag, address user) public view returns (bool) {
         bytes32 featureFlagHash = _hashFeatureFlag(featureFlag);
 
         return isFeatureFlagEnabled(featureFlagHash, user);
     }
 
+    /**
+     * @notice Checks if a feature flag is enabled for a specific user using the feature flag hash
+     * @dev Implements the logic for checking feature flag status, considering global and user-specific settings
+     * @param featureFlagHash Hash of the feature flag identifier
+     * @param user Address of the user to check
+     * @return bool True if the feature is enabled for the user
+     */
     function isFeatureFlagEnabled(bytes32 featureFlagHash, address user) public view returns (bool) {
-        bool globalStatus = featureFlagStatus[featureFlagHash][address(0)];
+        bool globalStatus = _featureFlagStatus[featureFlagHash][address(0)];
 
         if (user == address(0) || featureFlagImmutable[featureFlagHash]) {
             return globalStatus;
         } else if (globalStatus) {
             return true;
         }
-        return featureFlagStatus[featureFlagHash][user];
+        return _featureFlagStatus[featureFlagHash][user];
     }
 
+    /**
+     * @notice Hashes a feature flag string identifier
+     * @dev Internal helper function to consistently hash feature flag strings
+     * @param featureFlag String identifier to hash
+     * @return bytes32 Keccak256 hash of the feature flag string
+     */
     function _hashFeatureFlag(string memory featureFlag) internal pure returns (bytes32) {
         return keccak256(bytes(featureFlag));
     }

--- a/contracts/helpers/FeatureFlagRegistry.sol
+++ b/contracts/helpers/FeatureFlagRegistry.sol
@@ -80,7 +80,7 @@ contract FeatureFlagRegistry is AccessControl {
     function isFeatureFlagEnabled(bytes32 featureFlagHash, address user) public view returns (bool) {
         bool globalStatus = _featureFlagStatus[featureFlagHash][address(0)];
 
-        if (user == address(0) || featureFlagImmutable[featureFlagHash]) {
+        if (featureFlagImmutable[featureFlagHash]) {
             return globalStatus;
         } else if (globalStatus) {
             return true;

--- a/contracts/helpers/FeatureFlagRegistry.sol
+++ b/contracts/helpers/FeatureFlagRegistry.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
+
+contract FeatureFlagRegistry is AccessControl {
+    error CircuitBreakerTripped();
+
+    bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
+
+    mapping(bytes32 => mapping(address => bool)) public _featureFlagForAddress;
+    mapping(bytes32 => bool) public _featureFlagGlobalStatus;
+    mapping(bytes32 => bool) public _featureFlagCircuitBreaker;
+
+    constructor(address owner) {
+        _grantRole(DEFAULT_ADMIN_ROLE, owner);
+    }
+
+    function setFeatureFlagGlobalStatus(string memory featureFlag, bool status) public onlyRole(MANAGER_ROLE) {
+        bytes32 featureFlagHash = _hashFeatureFlag(featureFlag);
+        if (_featureFlagCircuitBreaker[featureFlagHash]) {
+            revert CircuitBreakerTripped();
+        }
+        _featureFlagGlobalStatus[featureFlagHash] = status;
+    }
+
+    function setFeatureFlagForAddress(string memory featureFlag, address user, bool status)
+        public
+        onlyRole(MANAGER_ROLE)
+    {
+        bytes32 featureFlagHash = _hashFeatureFlag(featureFlag);
+        if (_featureFlagCircuitBreaker[featureFlagHash]) {
+            revert CircuitBreakerTripped();
+        }
+        _featureFlagForAddress[featureFlagHash][user] = status;
+    }
+
+    function tripFeatureFlagCircuitBreaker(string memory featureFlag) public onlyRole(MANAGER_ROLE) {
+        bytes32 featureFlagHash = _hashFeatureFlag(featureFlag);
+        if (_featureFlagCircuitBreaker[featureFlagHash]) {
+            revert CircuitBreakerTripped();
+        }
+        _featureFlagCircuitBreaker[featureFlagHash] = true;
+    }
+
+    function isFeatureFlagEnabled(string memory featureFlag, address user) public view returns (bool) {
+        bytes32 featureFlagHash = _hashFeatureFlag(featureFlag);
+
+        return isFeatureFlagEnabled(featureFlagHash, user);
+    }
+
+    function isFeatureFlagEnabled(bytes32 featureFlagHash, address user) public view returns (bool) {
+        bool globalStatus = _featureFlagGlobalStatus[featureFlagHash];
+
+        if (_featureFlagCircuitBreaker[featureFlagHash]) {
+            return globalStatus;
+        } else if (globalStatus) {
+            return true;
+        }
+        return _featureFlagForAddress[featureFlagHash][user];
+    }
+
+    function _hashFeatureFlag(string memory featureFlag) internal pure returns (bytes32) {
+        return keccak256(bytes(featureFlag));
+    }
+}

--- a/contracts/helpers/FeatureFlagRegistry.sol
+++ b/contracts/helpers/FeatureFlagRegistry.sol
@@ -10,7 +10,7 @@ import {AccessControl} from "@openzeppelin/contracts/access/AccessControl.sol";
 contract FeatureFlagRegistry is AccessControl {
     error Immutable();
 
-    event FeatureFlagEnabled(bytes32 indexed featureFlagHash, address indexed user, bool status);
+    event FeatureFlagSet(bytes32 indexed featureFlagHash, address indexed user, bool status);
     event FeatureFlagImmutable(bytes32 indexed featureFlagHash);
 
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
@@ -41,7 +41,7 @@ contract FeatureFlagRegistry is AccessControl {
         }
         _featureFlagStatus[featureFlagHash][user] = status;
 
-        emit FeatureFlagEnabled(featureFlagHash, user, status);
+        emit FeatureFlagSet(featureFlagHash, user, status);
     }
 
     /**

--- a/deploy/deploy-feature-flag-registry.ts
+++ b/deploy/deploy-feature-flag-registry.ts
@@ -16,10 +16,8 @@ export default async function (): Promise<void> {
 
     const initialOwner = fundingWallet.address;
 
-    const implementation = await create2IfNotExists(hre, "SessionKeyPolicyRegistry", []);
+    const implementation = await create2IfNotExists(hre, "FeatureFlagRegistry", [initialOwner]);
 
-    await create2IfNotExists(hre, "ERC1967Proxy", [
-        await implementation.getAddress(), 
-        implementation.interface.encodeFunctionData("initialize", [initialOwner])
-    ]);
+    console.log("FeatureFlagRegistry deployed at", await implementation.getAddress());
 }
+

--- a/deploy/deploy.ts
+++ b/deploy/deploy.ts
@@ -4,16 +4,14 @@
  * Proprietary and confidential
  */
 import {
-    AbiCoder,
     hexlify,
     keccak256,
     ZeroAddress,
-    ZeroHash,
     zeroPadValue
 } from 'ethers';
 import * as hre from 'hardhat';
 import { Contract, Wallet, utils } from 'zksync-ethers';
-import { deployContract, getProvider, getWallet, verifyContract } from '../deploy/utils';
+import { create2IfNotExists, getProvider, getWallet, verifyContract } from '../deploy/utils';
 import type { CallStruct } from '../typechain-types/contracts/batch/BatchCaller';
 let fundingWallet: Wallet;
 
@@ -30,15 +28,15 @@ export default async function (): Promise<void> {
 
     const initialOwner = fundingWallet.address;
 
-    eoaValidator = await create2IfNotExists("EOAValidator", []);
-    implementation = await create2IfNotExists("AGWAccount", [await eoaValidator.getAddress()]);
-    registry = await create2IfNotExists("AGWRegistry", [initialOwner]);
-    await create2IfNotExists("AccountProxy", [await implementation.getAddress()]);
+    eoaValidator = await create2IfNotExists(hre, "EOAValidator", []);
+    implementation = await create2IfNotExists(hre, "AGWAccount", [await eoaValidator.getAddress()]);
+    registry = await create2IfNotExists(hre, "AGWRegistry", [initialOwner]);
+    await create2IfNotExists(hre, "AccountProxy", [await implementation.getAddress()]);
 
     const accountProxyArtifact = await hre.zksyncEthers.loadArtifact('AccountProxy');
     const bytecodeHash = utils.hashBytecode(accountProxyArtifact.bytecode);
     console.log("bytecodeHash", hexlify(bytecodeHash));
-    factory = await create2IfNotExists("AccountFactory", [await implementation.getAddress(), "0xb4e581f5", await registry.getAddress(), bytecodeHash, fundingWallet.address, initialOwner]);
+    factory = await create2IfNotExists(hre, "AccountFactory", [await implementation.getAddress(), "0xb4e581f5", await registry.getAddress(), bytecodeHash, fundingWallet.address, initialOwner]);
 
     const factoryAddress = await factory.getAddress();
     const isFactory = await registry.isFactory(factoryAddress);
@@ -47,48 +45,10 @@ export default async function (): Promise<void> {
         await registry.setFactory(factoryAddress);
     }
 
-    await create2IfNotExists("AAFactoryPaymaster", [await factory.getAddress()]);
-    await create2IfNotExists("SessionKeyValidator", []);
+    await create2IfNotExists(hre, "AAFactoryPaymaster", [await factory.getAddress()]);
+    await create2IfNotExists(hre, "SessionKeyValidator", []);
     
     await deployAccountIfNotExists(initialOwner);
-}
-
-
-async function create2IfNotExists(contractName: string, constructorArguments: any[]): Promise<Contract> {
-
-    const artifact = await hre.zksyncEthers.loadArtifact(contractName);
-    const bytecodeHash = utils.hashBytecode(artifact.bytecode);
-
-    const constructor = artifact.abi.find(abi => abi.type === "constructor");
-
-    let encodedConstructorArguments = "0x";
-    if (constructor) {
-        encodedConstructorArguments = AbiCoder.defaultAbiCoder().encode(constructor.inputs, constructorArguments);
-    }
-
-    const address = utils.create2Address("0x0000000000000000000000000000000000010000", bytecodeHash, ZeroHash, encodedConstructorArguments);
-    
-    const provider = getProvider(hre);
-    const code = await provider.getCode(address);
-    if (code !== "0x") {
-        console.log(`Contract ${contractName} already deployed at ${address}`);
-
-        // enable this to verify the contracts on a subsequent run
-        // await verifyContract(hre, {
-        //     address,
-        //     contract: artifact.sourceName,
-        //     constructorArguments: encodedConstructorArguments,
-        //     bytecode: artifact.bytecode
-        // })
-
-        return new Contract(address, artifact.abi, getWallet(hre));
-    }
-
-    return deployContract(hre, contractName, constructorArguments, {
-        wallet: getWallet(hre),
-        silent: false,
-    }, 'create2');
-
 }
 
 async function deployAccountIfNotExists(initialOwner: string) {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -59,6 +59,14 @@ const abstractTestnet: NetworkUserConfig = {
     chainId: 11124,
 }
 
+const abstractMainnet: NetworkUserConfig = {
+    url: "https://api.mainnet.abs.xyz",
+    ethNetwork: "mainnet",
+    zksync: true,
+    verifyURL: 'https://api-explorer-verify.mainnet.abs.xyz/contract_verification',
+    chainId: 2741,
+}
+
 const config: HardhatUserConfig = {
     zksolc: {
         version: '1.5.6',
@@ -83,6 +91,14 @@ const config: HardhatUserConfig = {
                     browserURL: 'https://sepolia.abscan.org',
                 },
             },
+            {
+                network: 'abstractMainnet',
+                chainId: 2741,
+                urls: {
+                    apiURL: 'https://api.abscan.org/api',
+                    browserURL: 'https://abscan.org',
+                },
+            },
         ],
     },
     networks: {
@@ -93,6 +109,7 @@ const config: HardhatUserConfig = {
         zkSyncSepolia,
         zkSyncMainnet,
         abstractTestnet,
+        abstractMainnet,
         inMemoryNode,
         dockerizedNode,
     },


### PR DESCRIPTION
- **create onchain feature flag registry**
- **add events; use address 0 for global status**
- **clean up**
- **remove redundant check**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a new `FeatureFlagRegistry` smart contract for managing feature flags on-chain, adds support for an `abstractMainnet` network configuration, and refines deployment scripts to utilize a `create2IfNotExists` utility function.

### Detailed summary
- Added `abstractMainnet` network configuration to `hardhat.config.ts`.
- Introduced `FeatureFlagRegistry` contract in `contracts/helpers/FeatureFlagRegistry.sol`.
- Updated deployment scripts to use `create2IfNotExists` function.
- Removed redundant `create2IfNotExists` function from deployment scripts.
- Enhanced `create2IfNotExists` function to include network configuration and deployment checks.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->