### PR TITLE
selector updates

### DIFF
--- a/deploy/add-approved-session-keys-to-registry.ts
+++ b/deploy/add-approved-session-keys-to-registry.ts
@@ -13,7 +13,7 @@ export default async function (): Promise<void> {
   const wallet = getWallet(hre);
 
   // Use the default registry contract address from create2 or override if one is provided via CLI args
-  const DEFAULT_REGISTRY_ADDRESS = "0x7dA0211D162a26839Bbb8232Da13fbE068440d95";
+  const DEFAULT_REGISTRY_ADDRESS = "0xfD20b9d7A406e2C4f5D6Df71ABE3Ee48B2EccC9F";
   const registryAddress =
     process.argv.slice(2).indexOf("--registry-address") >= 0
       ? process.argv[process.argv.slice(2).indexOf("--registry-address") + 3]
@@ -53,7 +53,9 @@ export default async function (): Promise<void> {
           config.selector
         );
 
-        if (currentStatus === config.status) {
+
+
+        if (currentStatus === BigInt(config.status)) {
           console.warn(
             `${description} already set to ${Status[config.status]}. Skipping.`
           );
@@ -71,7 +73,7 @@ export default async function (): Promise<void> {
         description = `Transfer policy for target: ${config.target}`;
         currentStatus = await registry.getTransferPolicyStatus(config.target);
 
-        if (currentStatus === config.status) {
+        if (currentStatus === BigInt(config.status)) {
           console.warn(
             `${description} already set to ${Status[config.status]}. Skipping.`
           );
@@ -91,7 +93,7 @@ export default async function (): Promise<void> {
           config.target
         );
 
-        if (currentStatus === config.status) {
+        if (currentStatus === BigInt(config.status)) {
           console.warn(
             `${description} already set to ${Status[config.status]}. Skipping.`
           );

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -161,19 +161,19 @@ const sampleConfig4: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
-    selector: "0xf088d547", // buy selector
+    selector: "0xcce7ec13", // buy(address,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
-    selector: "0xe65e7daf", // sell selector
+    selector: "0xe1adf47b", // sell(address,uint112,uint112)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x42b2c802205b908030Bc374c1D30Cc4997FC199a",
-    selector: "0x2a1b1f7f", // deployToken selector
+    selector: "0x028221cc", // deployToken(address,address,string,string,uint256,string,string,bytes32)
     status: Status.Allowed,
   },
 ];
@@ -210,7 +210,7 @@ const sampleConfig6: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0xB4b55C656c6b89f020a6E1044B66D227B638C474",
-    selector: "0x9b2c0a37", // requestTokenSpin selector
+    selector: "0x08bc2601", // requestTokenSpin(uint8,address,uint256)
     status: Status.Allowed,
   },
   {
@@ -225,31 +225,31 @@ const sampleConfig7: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x03c9FEC896BC1a69EDAafaC47B6A1D473b864078",
-    selector: "0x073f5da3", // joinTournament selector
+    selector: "0x073f5da3", // joinTournament(bytes,string,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x0C1Fb514EEe951F43d549666Bec113D9ADcFBf98",
-    selector: "0xda568094", // claimPrize selector
+    selector: "0xda568094", // claimPrize(bytes,string,uint256,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x0C1Fb514EEe951F43d549666Bec113D9ADcFBf98",
-    selector: "0xdaa462ae", // claimMultiplePrizes selector
+    selector: "0xdaa462ae", // claimMultiplePrizes(bytes[],string[],uint256[],uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x1FD611a870c44f8EFa82CF62B67499D141abD7E9",
-    selector: "0x8589ee97", // claimReferral selector
+    selector: "0x8589ee97", // claimReferral(bytes,string,uint256,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x1FD611a870c44f8EFa82CF62B67499D141abD7E9",
-    selector: "0xda4053ac", // claimMultipleReferrals selector
+    selector: "0xda4053ac", // claimMultipleReferrals(bytes[],string[],uint256[],uint256)
     status: Status.Allowed,
   },
 ];
@@ -258,61 +258,61 @@ const sampleConfig8: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0xdef25acb", // createDrop selector
+    selector: "0xdef25acb", // createDrop(uint256,uint256,bool,bool,bytes,uint256,uint256,uint256,uint256,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0x7f58b4bf", // mintToken selector
+    selector: "0x7f58b4bf", // mintToken(uint256,bytes,uint256,bool,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0xeefdc1df", // mintTokenByCreator
+    selector: "0xeefdc1df", // mintTokenByCreator(uint256,bytes,address,uint256,bool,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0x42d96dd7", // refundToken selector
+    selector: "0x42d96dd7", // refundToken(uint256,uint256,uint256,bytes)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0x91eb290e", // batchRedeem selector
+    selector: "0x91eb290e", // batchRedeem(uint256[],uint256,uint256[],bytes)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0x96949420", // joinQueue selector
+    selector: "0x96949420", // joinQueue(uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0xae796ab3", // leaveQueue selector
+    selector: "0xae796ab3", // leaveQueue(uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0x0dce83c7", // commitQueue selector
+    selector: "0x0dce83c7", // commitQueue(uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0xd8d07eda", // revealQueue selector
+    selector: "0xd8d07eda", // revealQueue(uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
-    selector: "0x5beaa049", // claimFromQueue selector
+    selector: "0x5beaa049", // claimFromQueue(uint256)
     status: Status.Allowed,
   },
 ];

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -194,7 +194,7 @@ const sampleConfig5: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
-    selector: "0x5d7a2f89", // purchase(uint256,uint16,address,address,uint256,uint256)
+    selector: "0x83a84ba9", // claimReferralFees()
     status: Status.Allowed,
   },
   {

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -381,13 +381,19 @@ const sampleConfig9: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
-    selector: "0x8d1a7289", // validateServiceExecution(uint256,uint256)
+    selector: "0x14879aae", // validateServiceExecution(uint256,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
     selector: "0x7b15f1b6", // createService(string,string,uint256)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
+    selector: "0x52a74c0a", // createAndUpdateFromService(uint256,uint256)
     status: Status.Allowed,
   },
 ];

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -200,7 +200,7 @@ const sampleConfig5: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
-    selector: "0x4e71d92d", // claim(uint256)
+    selector: "0x379607f5", // claim(uint256)
     status: Status.Allowed,
   },
   

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -77,43 +77,43 @@ const sampleConfig2: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0xb1a1a882", // depositETH selector
+    selector: "0x2e599054", // depositETH(address,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0x47e7ef24", // deposit selector
+    selector: "0x8340f549", // deposit(address,address,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0x4782f779", // withdrawETH selector
+    selector: "0xf14210a6", // withdrawETH(uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0x69328dec", // withdraw selector
+    selector: "0xf3fef3a3", // withdraw(address,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0xc2708f09", // expire selector
+    selector: "0xc2708f09", // expire((address,address,uint32,uint64,address,uint96,address,bytes))
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0xbc011e72", // solve selector
+    selector: "0xbc011e72", // solve((address,address,uint32,uint64,address,uint96,address,bytes),bytes32,bytes)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x0b4429576e5ed44a1b8f676c8217eb45707afa3d",
-    selector: "0x19b410fe", // coin selector
+    selector: "0x19b410fe", // coin((address,address,uint32,uint64,address,uint96,address,bytes),bytes,uint256)
     status: Status.Allowed,
   },
 ];
@@ -122,19 +122,19 @@ const sampleConfig3: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    selector: "0xe4849b32", // sell selector
+    selector: "0x3620875e", // sell(uint256,uint256,uint256,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    selector: "0xd6bbd32d", // buy selector
+    selector: "0x1281311d", // buy(uint256,uint256,uint256,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
-    selector: "0x4f1ddc4f", // claimWinnings selector
+    selector: "0x677bd9ff", // claimWinnings(uint256)
     status: Status.Allowed,
   },
   {

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -182,21 +182,28 @@ const sampleConfig5: PolicyConfig[] = [
   {
     type: PolicyType.Call,
     target: "0x3439153EB7AF838Ad19d56E1571FBD09333C2809",
-    selector: "0x2e1a7d4d", // withdraw selector
+    selector: "0x2e1a7d4d", // withdraw(uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
-    selector: "0x8f5d96d0", // purchaseETH selector
+    selector: "0xf310d2e6", // purchaseETH(uint256,uint16,address,address,uint256,uint256)
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
-    selector: "0x4e71d92d", // claim selector
+    selector: "0x5d7a2f89", // purchase(uint256,uint16,address,address,uint256,uint256)
     status: Status.Allowed,
   },
+  {
+    type: PolicyType.Call,
+    target: "0x3272596F776470D2D7C3f7dfF3dc50888b7D8967",
+    selector: "0x4e71d92d", // claim(uint256)
+    status: Status.Allowed,
+  },
+  
 ];
 
 const sampleConfig6: PolicyConfig[] = [

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -39,15 +39,15 @@ export type PolicyConfig =
 
 const sampleConfig0: PolicyConfig[] = [
   {
-    type: PolicyType.Call,
-    target: "0x57E12aBdF617FcD0D2ab6984C289075aA90CAc8C",
-    selector: "0xa22cb465", // setApprovalForAll selector
+    type: PolicyType.ApprovalTarget,
+    token: "0x57E12aBdF617FcD0D2ab6984C289075aA90CAc8C",
+    target: "0xF99E6e273a90Fac72F3692B033A46e8b602DC44e",
     status: Status.Allowed,
   },
   {
     type: PolicyType.Call,
     target: "0xF99E6e273a90Fac72F3692B033A46e8b602DC44e",
-    selector: "0x42966c68", // burnAndMint selector
+    selector: "0xee026cab", // burnAndMint(uint256[],uint256[])
     status: Status.Allowed,
   },
 ];

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -138,6 +138,12 @@ const sampleConfig3: PolicyConfig[] = [
     status: Status.Allowed,
   },
   {
+    type: PolicyType.Call,
+    target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
+    selector: "0xec93f0f5", // claimVoidedOutcomeShares(uint256,uint256)
+    status: Status.Allowed,
+  },
+  {
     type: PolicyType.ApprovalTarget,
     token: "0xf19609e96187cdaa34cffb96473fac567e547302", // PTS
     target: "0x4f4988A910f8aE9B3214149A8eA1F2E4e3Cd93CC",
@@ -398,6 +404,45 @@ const sampleConfig9: PolicyConfig[] = [
   },
 ];
 
+const sampleConfig10: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x06D7Ee1D50828Ca96e11890A1601f6fe61F1e584",
+    selector: "0xfe939afc", // stakeMany(uint256[])
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x06D7Ee1D50828Ca96e11890A1601f6fe61F1e584",
+    selector: "0x0d50c189", // unstakeMany(uint256[])
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x06D7Ee1D50828Ca96e11890A1601f6fe61F1e584",
+    selector: "0x925489a8", // claimMany(uint256[])
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x06D7Ee1D50828Ca96e11890A1601f6fe61F1e584",
+    selector: "0x8ca96347", // upgradeMany(uint256[])
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0xeEa334B302BD8b1b96D4EF73B8f4467a347dA6f0",
+    selector: "0x22b46e42", // stakeMany(uint256[],uint8)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0xeEa334B302BD8b1b96D4EF73B8f4467a347dA6f0",
+    selector: "0xc63db6bd", // requestUnstakeMany(uint256[])
+    status: Status.Allowed,
+  },
+
+]
 
 // Session key configurations to approve from the sample configurations
 export const sessionKeysToApprove: PolicyConfig[] = [
@@ -411,4 +456,5 @@ export const sessionKeysToApprove: PolicyConfig[] = [
   ...sampleConfig7,
   ...sampleConfig8,
   ...sampleConfig9,
+  ...sampleConfig10,
 ];

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -335,6 +335,64 @@ const sampleConfig8: PolicyConfig[] = [
   },
 ];
 
+const sampleConfig9: PolicyConfig[] = [
+  {
+    type: PolicyType.Call,
+    target: "0x0DA6Bfd5d50edb31AF14C3A7820d28dB475Ec97D",
+    selector: "0x2268a972", // buyCredits(string,uint256,address) 
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x0DA6Bfd5d50edb31AF14C3A7820d28dB475Ec97D",
+    selector: "0xeccc35fe", // sellCredits(string,uint256,address)
+    status: Status.Allowed,
+  }, 
+  {
+    type: PolicyType.Call,
+    target: "0x0DA6Bfd5d50edb31AF14C3A7820d28dB475Ec97D",
+    selector: "0x406f9248", // claimCreatorFee(string)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
+    selector: "0x45351035", // requestServiceExecution(uint256,string)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
+    selector: "0xbc467855", // acceptServiceExecution(uint256,uint256,string)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
+    selector: "0xa7e52baa", // cancelServiceExecution(uint256,uint256,string)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
+    selector: "0x2add845c", // disputeServiceExecution(uint256,uint256,string)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
+    selector: "0x8d1a7289", // validateServiceExecution(uint256,uint256)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x89e74F963e506D6921FF33cB75b53b963D7218bE",
+    selector: "0x7b15f1b6", // createService(string,string,uint256)
+    status: Status.Allowed,
+  },
+];
+
+
 // Session key configurations to approve from the sample configurations
 export const sessionKeysToApprove: PolicyConfig[] = [
   ...sampleConfig0,
@@ -346,4 +404,5 @@ export const sessionKeysToApprove: PolicyConfig[] = [
   ...sampleConfig6,
   ...sampleConfig7,
   ...sampleConfig8,
+  ...sampleConfig9,
 ];

--- a/deploy/const/session-key-configs.ts
+++ b/deploy/const/session-key-configs.ts
@@ -257,6 +257,24 @@ const sampleConfig7: PolicyConfig[] = [
 const sampleConfig8: PolicyConfig[] = [
   {
     type: PolicyType.Call,
+    target: "0x3B50dE27506f0a8C1f4122A1e6F470009a76ce2A",
+    selector: "0x7060a227",
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0xf242432a", // safeTransferFrom(address,address,uint256,uint256,bytes)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
+    target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
+    selector: "0x2eb2c2d6", // safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)
+    status: Status.Allowed,
+  },
+  {
+    type: PolicyType.Call,
     target: "0x458422e93BF89A109afc4fac00aAcF2F18FcF541",
     selector: "0xdef25acb", // createDrop(uint256,uint256,bool,bool,bytes,uint256,uint256,uint256,uint256,uint256)
     status: Status.Allowed,


### PR DESCRIPTION
- **update selectors for contract**
- **update selectors**

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates session key configurations and modifies the default registry address. It enhances type safety by ensuring `config.status` comparisons use `BigInt` and introduces new policy configurations for various contract interactions.

### Detailed summary
- Changed `DEFAULT_REGISTRY_ADDRESS` from `0x7dA0211D162a26839Bbb8232Da13fbE068440d95` to `0xfD20b9d7A406e2C4f5D6Df71ABE3Ee48B2EccC9F`.
- Updated comparisons of `currentStatus` with `config.status` to use `BigInt`.
- Modified existing `PolicyConfig` entries, changing `type`, `target`, and `selector` values across multiple configurations.
- Added new `sampleConfig9` and `sampleConfig10` with various contract interaction methods.
- Expanded `sessionKeysToApprove` to include new configurations from `sampleConfig9` and `sampleConfig10`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->