### PR TITLE
fix: incorrect grouping of operators in `ord` function

### DIFF
--- a/contracts/libraries/StringUtils.sol
+++ b/contracts/libraries/StringUtils.sol
@@ -338,7 +338,7 @@ library strings {
         for (uint i = 1; i < length; i++) {
             divisor = divisor / 256;
             b = (word / divisor) & 0xFF;
-            if (b & 0xC0 != 0x80) {
+            if ((b & 0xC0) != 0x80) {
                 // Invalid UTF-8 sequence
                 return 0;
             }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on correcting the conditional check in the `StringUtils.sol` file to ensure proper validation of UTF-8 sequences.

### Detailed summary
- Modified the conditional statement from `if (b & 0xC0 != 0x80)` to `if ((b & 0xC0) != 0x80)`. 
- This change adds parentheses for clarity and corrects the precedence of the bitwise operation, ensuring accurate UTF-8 sequence validation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->