### PR TITLE
update to latest zksync-contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
+        "@matterlabs/zksync-contracts": "28.0.1",
         "@nomad-xyz/excessively-safe-call": "github:nomad-xyz/ExcessivelySafeCall",
         "@openzeppelin/contracts": "5.1.0",
         "@openzeppelin/contracts-upgradeable": "5.1.0",
@@ -2776,9 +2776,9 @@
       }
     },
     "node_modules/@matterlabs/zksync-contracts": {
-      "version": "1.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/@matterlabs/zksync-contracts/-/zksync-contracts-1.0.0-alpha.9.tgz",
-      "integrity": "sha512-n5gkjhj0s4IAUfovTrBLVauGzt+dz5w8qHPLjdrB3Szs9BnVsIxLZico9mIAeisICryH7ysqtCShgRZyo0bLow==",
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@matterlabs/zksync-contracts/-/zksync-contracts-28.0.1.tgz",
+      "integrity": "sha512-WomRTQPED/soIH6nsexs8y/BIUjj9226x33kAfXXSSFUpK1EFjJQ9fshYTPZ/RMKTa4BuVVBakh4kuvl4HoabA==",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/contracts": "=5.2.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "author": "abs.xyz",
   "dependencies": {
-    "@matterlabs/zksync-contracts": "1.0.0-alpha.9",
+    "@matterlabs/zksync-contracts": "28.0.1",
     "@nomad-xyz/excessively-safe-call": "github:nomad-xyz/ExcessivelySafeCall",
     "@openzeppelin/contracts": "5.1.0",
     "@openzeppelin/contracts-upgradeable": "5.1.0",
@@ -39,6 +39,7 @@
   "main": "index.js",
   "scripts": {
     "compile": "npx hardhat compile",
+    "compile:foundry": "forge build --zksync",
     "deploy:mvp": "npx hardhat deploy-zksync --script deploy-mvp.ts",
     "lint": "npx prettier --write --plugin=prettier-plugin-solidity 'contracts/**/*.sol'",
     "lint-check": "npx prettier --list-different --plugin=prettier-plugin-solidity 'contracts/**/*.sol'",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the version of the `@matterlabs/zksync-contracts` dependency from `1.0.0-alpha.9` to `28.0.1` in both `package.json` and `package-lock.json`. Additionally, it introduces a new script for building with Foundry.

### Detailed summary
- Updated `@matterlabs/zksync-contracts` from `1.0.0-alpha.9` to `28.0.1` in `package.json`.
- Updated `@matterlabs/zksync-contracts` from `1.0.0-alpha.9` to `28.0.1` in `package-lock.json`.
- Added new script `compile:foundry` to `package.json`: `"forge build --zksync"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->