### PR TITLE
update packages and anvil-zksync

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -69,7 +69,7 @@ const abstractMainnet: NetworkUserConfig = {
 
 const config: HardhatUserConfig = {
     zksyncAnvil: {
-        version: "0.6.5",
+        version: "0.6.8",
     },
     zksolc: {
         version: '1.5.6',

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "ts-morph": "^19.0.0"
       },
       "devDependencies": {
-        "@matterlabs/hardhat-zksync": "1.6.0",
+        "@matterlabs/hardhat-zksync": "1.6.1",
         "@matterlabs/hardhat-zksync-verify": "1.8.1",
         "@nomicfoundation/hardhat-chai-matchers": "2.0.9",
         "@nomicfoundation/hardhat-ethers": "3.0.9",
@@ -2535,19 +2535,19 @@
       }
     },
     "node_modules/@matterlabs/hardhat-zksync": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@matterlabs/hardhat-zksync/-/hardhat-zksync-1.6.0.tgz",
-      "integrity": "sha512-z02oxdiSW3rVPn0RBPIR1dODnPCMK1u50PBM1iF88wAua/EDYrkdl6eEtyQc1GiQxY5NPznbnRHSMDlF4PYmIw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@matterlabs/hardhat-zksync/-/hardhat-zksync-1.6.1.tgz",
+      "integrity": "sha512-a7IYU6Yk1/2z/VQjjDtzZVZlVmxpPyQne7w0QdL3yIYvV4iTtWHGoylLDY4Qg8vfGm4FFgMdNXR+LxU87uuiDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@matterlabs/hardhat-zksync-deploy": "^1.7.0",
         "@matterlabs/hardhat-zksync-ethers": "^1.3.0",
-        "@matterlabs/hardhat-zksync-node": "^1.5.0",
-        "@matterlabs/hardhat-zksync-solc": "^1.3.2",
+        "@matterlabs/hardhat-zksync-node": "^1.5.2",
+        "@matterlabs/hardhat-zksync-solc": "^1.4.0",
         "@matterlabs/hardhat-zksync-telemetry": "^1.1.1",
         "@matterlabs/hardhat-zksync-upgradable": "^1.9.0",
-        "@matterlabs/hardhat-zksync-verify": "^1.8.0",
+        "@matterlabs/hardhat-zksync-verify": "^1.8.1",
         "@nomicfoundation/hardhat-verify": "^2.0.0",
         "@openzeppelin/upgrades-core": "^1.37.0",
         "chai": "^4.3.4",
@@ -2560,11 +2560,11 @@
       "peerDependencies": {
         "@matterlabs/hardhat-zksync-deploy": "^1.7.0",
         "@matterlabs/hardhat-zksync-ethers": "^1.3.0",
-        "@matterlabs/hardhat-zksync-node": "^1.5.0",
-        "@matterlabs/hardhat-zksync-solc": "^1.3.2",
+        "@matterlabs/hardhat-zksync-node": "^1.5.2",
+        "@matterlabs/hardhat-zksync-solc": "^1.4.0",
         "@matterlabs/hardhat-zksync-telemetry": "^1.1.1",
         "@matterlabs/hardhat-zksync-upgradable": "^1.9.0",
-        "@matterlabs/hardhat-zksync-verify": "^1.8.0"
+        "@matterlabs/hardhat-zksync-verify": "^1.8.1"
       }
     },
     "node_modules/@matterlabs/hardhat-zksync-deploy": {
@@ -2659,13 +2659,13 @@
       }
     },
     "node_modules/@matterlabs/hardhat-zksync-node": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@matterlabs/hardhat-zksync-node/-/hardhat-zksync-node-1.5.1.tgz",
-      "integrity": "sha512-46i8gJ3jvZh2s8PQ302hrujQVP2y3dnrCNaelBrEwbO6aTdC4qDCIl6d3AWn7HqlfWYQO7rPvMtXHXRATVfaSg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@matterlabs/hardhat-zksync-node/-/hardhat-zksync-node-1.5.2.tgz",
+      "integrity": "sha512-I9icYktw4T09hOsajqRvZKaaQ6pmau7qkuHgPW8Azq3haK0MF+mq6ErkSqXzV6qPy9gg8mT885Xy36jMi86sbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@matterlabs/hardhat-zksync-solc": "^1.3.2",
+        "@matterlabs/hardhat-zksync-solc": "^1.4.0",
         "@matterlabs/hardhat-zksync-telemetry": "^1.1.1",
         "axios": "^1.7.2",
         "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ts-morph": "^19.0.0"
   },
   "devDependencies": {
-    "@matterlabs/hardhat-zksync": "1.6.0",
+    "@matterlabs/hardhat-zksync": "1.6.1",
     "@matterlabs/hardhat-zksync-verify": "1.8.1",
     "@nomicfoundation/hardhat-chai-matchers": "2.0.9",
     "@nomicfoundation/hardhat-ethers": "3.0.9",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the versions of several packages and dependencies in the `hardhat.config.ts`, `package.json`, and `package-lock.json` files, enhancing compatibility and incorporating improvements.

### Detailed summary
- Updated `version` in `zksyncAnvil` from `0.6.5` to `0.6.8`.
- Updated `@matterlabs/hardhat-zksync` from `1.6.0` to `1.6.1` in `package.json` and `package-lock.json`.
- Updated `@matterlabs/hardhat-zksync-node` from `1.5.0` to `1.5.2`.
- Updated `@matterlabs/hardhat-zksync-solc` from `1.3.2` to `1.4.0`.
- Updated `@matterlabs/hardhat-zksync-verify` from `^1.8.0` to `^1.8.1`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->